### PR TITLE
Fix a bug in ppm calculation on Windows

### DIFF
--- a/src/fx2adc_test.c
+++ b/src/fx2adc_test.c
@@ -168,7 +168,7 @@ static void ppm_test(uint32_t len)
 	static uint64_t interval = 0;
 	static uint64_t nsamples_total = 0;
 	static uint64_t interval_total = 0;
-	struct time_generic ppm_now;
+	static struct time_generic ppm_now;
 	static struct time_generic ppm_recent;
 	static enum {
 		PPM_INIT_NO,


### PR DESCRIPTION
`ppm_now` in `ppm_test` is a local, non-static variable and therefore uninitialized, causing undefined behavior in the WIN32 version of `ppm_gettime`. This patch makes the variable static so that the `tg->init` state is correctly initialized to 0 and preserved between function invocations.